### PR TITLE
chore: enforce 80% test coverage in CI workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,10 +39,10 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Maven test
-        run: mvn -B test
+      - name: Maven verify (with coverage check)
+        run: mvn -B verify
 
-      - name: Upload JaCoCo report (optional)
+      - name: Upload JaCoCo report
         if: always()
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
Enforces 80% test coverage requirement in GitHub Actions CI workflow.

## Problem
As discussed in the group and pointed out by @MichaelMcKibbin, the team has had a gap in practicing `mvn verify` to enforce JaCoCo coverage checks.

Currently, CI runs `mvn test` which:
- Runs tests
- Generates JaCoCo report
- Does NOT enforce the 80% minimum coverage check

## Propsoed solution
Changed CI workflow from `mvn test` to `mvn verify`.

## Impact
- Builds will fail if coverage drops below 80%
- Ensures project meets submission requirements
- Catches coverage issues early in PRs
- May slow down initial development but reduces rework later

## References
- Project Brief: "80%+ test coverage (verified by JaCoCo report)"
- pom.xml lines 48-67: JaCoCo check configuration

Closes #49 