### PR TITLE
fix: reject empty/whitespace-only column names in Headers

### DIFF
--- a/src/main/java/com/group5/csv/core/Headers.java
+++ b/src/main/java/com/group5/csv/core/Headers.java
@@ -19,7 +19,8 @@ public class Headers {
      * Lookup is case-insensitive for better user experience.
      * 
      * @param columnNames ordered list of column names from CSV header
-     * @throws IllegalArgumentException if columnNames is null, empty, contains null, or has duplicates
+     * @throws IllegalArgumentException if columnNames is null, empty, contains null, 
+     *                                  contains empty/whitespace-only strings, or has duplicates
      */
     public Headers(List<String> columnNames) {
         if (columnNames == null || columnNames.isEmpty()) {
@@ -36,6 +37,11 @@ public class Headers {
             }
             
             String trimmed = name.trim();
+            
+            if (trimmed.isEmpty()) {
+                throw new IllegalArgumentException("Column name cannot be empty or whitespace-only");
+            }
+            
             String normalized = trimmed.toLowerCase();
             
             if (nameToIndex.containsKey(normalized)) {

--- a/src/test/java/com/group5/csv/core/HeadersTest.java
+++ b/src/test/java/com/group5/csv/core/HeadersTest.java
@@ -50,6 +50,38 @@ class HeadersTest {
         });
     }
     
+    @Test
+    void shouldThrowExceptionForEmptyStringColumnName() {
+        List<String> columns = Arrays.asList("id", "", "name");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Headers(columns);
+        });
+    }
+    
+    @Test
+    void shouldThrowExceptionForWhitespaceOnlyColumnName() {
+        List<String> columns = Arrays.asList("id", "   ", "name");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Headers(columns);
+        });
+    }
+    
+    @Test
+    void shouldThrowExceptionForTabOnlyColumnName() {
+        List<String> columns = Arrays.asList("id", "\t\t", "name");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Headers(columns);
+        });
+    }
+    
+    @Test
+    void shouldThrowExceptionForMixedWhitespaceOnlyColumnName() {
+        List<String> columns = Arrays.asList("id", " \t \n ", "name");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Headers(columns);
+        });
+    }
+    
     // Whitespace Trimming Tests
     
     @Test


### PR DESCRIPTION
### Summary
Fixes #68 - Headers constructor now properly validates that column names are not empty or whitespace-only after trimming.

### Problem
Previously, column names like `"   "` (whitespace-only) would be trimmed to `""` and accepted, leading to:
- Empty string column names in the Headers object
- Confusing behavior when accessing columns
- Potential downstream issues

### Solution
- Add validation after trim() to check isEmpty()
- Add tests covering edge cases:
-- Empty string
-- Whitespace-only (spaces)
-- Tab-only
-- Mixed whitespace (spaces, tabs, newlines)
- Update JavaDoc to document new validation

Closes #68