### PR TITLE
Change printableLineSeparator to public access

### DIFF
--- a/src/main/java/com/group5/csv/io/CsvFormat.java
+++ b/src/main/java/com/group5/csv/io/CsvFormat.java
@@ -298,7 +298,7 @@ public final class CsvFormat {
         };
     }
 
-    private static String printableLineSeparator(String sep) {
+    public static String printableLineSeparator(String sep) {
         return sep.replace("\r", "\\r").replace("\n", "\\n");
     }
 


### PR DESCRIPTION
printableLineSeparator is now public so that CsvReader can add the newline character to its search string.