### PR TITLE
fix: Update maven-surefire-plugin to support JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,13 @@
                 <version>3.13.0</version>
                 <configuration>
                     <release>21</release>
-
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Problem
Tests were not being discovered or executed because `maven-surefire-plugin 2.17` doesn't support `JUnit 5`.
This fixed #99 .

## Solution
Updated maven-surefire-plugin from `2.17` to `3.2.5` in `pom.xml`

All maven builds are completing and pass/reports look good:
- mvn test
- mvn jacoco:report
- mvn clean package 

## Results

```
[INFO] Results:
[INFO] 
[INFO] Tests run: 389, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.12:report (report) @ csv-data-processor ---
[INFO] Loading execution data file /home/edson/Documents/ATU/SoftwareDevelopment/ATU-SoftDev-Grp5Project/target/jacoco.exec
[INFO] Analyzed bundle 'csv-data-processor' with 49 classes
[INFO] 
[INFO] --- jar:3.1.2:jar (default-jar) @ csv-data-processor ---
[INFO] Building jar: /home/edson/Documents/ATU/SoftwareDevelopment/ATU-SoftDev-Grp5Project/target/csv-data-processor-1.0-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.750 s
[INFO] Finished at: 2025-11-30T14:37:44Z
[INFO] ------------------------------------------------------------------------
```

---

### Before:

<img width="1113" height="322" alt="Screenshot From 2025-11-30 14-30-28" src="https://github.com/user-attachments/assets/b6b70950-121d-408c-8a1e-02d18384f58e" />



---

### After:

<img width="1049" height="273" alt="Screenshot From 2025-11-30 14-41-42" src="https://github.com/user-attachments/assets/4442597f-81ea-44da-97e3-472e66ed9721" />



