### PR TITLE
CsvWriter now supports writeBom and hasHeader settings

### DIFF
--- a/src/main/java/com/group5/csv/io/CsvConfig.java
+++ b/src/main/java/com/group5/csv/io/CsvConfig.java
@@ -171,7 +171,7 @@ public final class CsvConfig {
         private boolean requireUniformFieldCount = false;
         private boolean skipEmptyLines = true;
         private Charset charset = StandardCharsets.UTF_8;
-        private boolean writeBOM = true;
+        private boolean writeBOM = false;
         private int readBufSize = 8192;
 
         /**

--- a/src/test/java/com/group5/csv/io/CsvConfigTest.java
+++ b/src/test/java/com/group5/csv/io/CsvConfigTest.java
@@ -18,7 +18,7 @@ class CsvConfigTest {
         assertFalse(config.isRequireUniformFieldCount());
         assertTrue(config.isSkipEmptyLines());
         assertEquals(StandardCharsets.UTF_8, config.getCharset());
-        assertTrue(config.isWriteBOM());
+        assertFalse(config.isWriteBOM());
         assertEquals(8192, config.getReadBufSize());
     }
 


### PR DESCRIPTION
### Summary

This PR refactors `CsvWriter` to rely exclusively on an `OutputStream`-based API and aligns BOM handling with byte-level output.

### Key changes

* Removed `CsvWriter(Writer, CsvConfig)` constructor (API change)
* `CsvWriter` now accepts only `OutputStream` as input
* Ensures correct and reliable BOM handling at the byte level
* `CsvConfig.writeBom` now defaults to `false`
* Updated unit tests to use `OutputStream` instead of `Writer`
* Added coverage for BOM behavior using UTF-8 / UTF-16 streams

### Rationale

`Writer`-based construction made it impossible to reliably control BOM output, since writers operate on characters instead of raw bytes. Restricting construction to `OutputStream` provides predictable encoding behavior, clearer intent, and prevents subtle data corruption issues.

Defaulting `writeBom` to `false` avoids unexpected BOMs in generated CSV files while keeping the feature explicitly opt-in.

### Migration note

Code using:

```java
new CsvWriter(Writer, CsvConfig)
```

must be replaced with:

```java
new CsvWriter(OutputStream, CsvConfig)
```

For file-based output, use:

```java
CsvWriter.toPath(Path, CsvConfig)
```

Fixes #109